### PR TITLE
feat(bash): add mddoc script for generically adding markdown inline 

### DIFF
--- a/bash/mddoc
+++ b/bash/mddoc
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Copyright 2021 Blockchain Technology Partners
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# shellcheck disable=SC1090
+grep '^\s*## @md' "$1" | sed -e 's/^\s*## @md \s*//'


### PR DESCRIPTION
Super simple system to add inline markdown documentation.  Currently works with any sort of file that accepts `#` as a comment marker, e.g. scripts, yaml, etc.  Will add support for other line comment variations later.
Signed-off-by: Kevin O'Donnell <kevin@blockchaintp.com>