### PR TITLE
fix(bash): update-repo-tags should add links when it gens changelog

### DIFF
--- a/bash/update-repo-tags
+++ b/bash/update-repo-tags
@@ -71,7 +71,7 @@ if [ "$skip" = "false" ]; then
     git::cmd tag "$TAG"
   else
     if [ "$GENERATE_CHANGELOG" = "true" ]; then
-      "$(dirs::of)"/changelog | sed -e "s/Unreleased/$TAG/" >CHANGELOG.md
+      "$(dirs::of)"/changelog -l | sed -e "s/Unreleased/$TAG/" >CHANGELOG.md
       git add CHANGELOG.md
       git commit --no-verify -m "ci: Update CHANGELOG releasing $TAG" CHANGELOG.md
     fi


### PR DESCRIPTION
Signed-off-by: Kevin O'Donnell <kevin@blockchaintp.com>