### PR TITLE
fix(k8s-support-collector): handle when cluster names contain '/'

### DIFF
--- a/bash/k8s-support-collector
+++ b/bash/k8s-support-collector
@@ -109,6 +109,7 @@ function create_package {
   if [ "${ALL_NAMESPACES}" = "true" ]; then
     file="$cluster.ALL-${now}.tar.gz"
   fi
+  file=${file/\//_}
   log::notice "Creating package $file"
   find "${OUT_DIR}" -type f -print0 | sed -e "s@$OUT_DIR/@@g" |
     xargs -0 tar cfz "$file" -C "${OUT_DIR}"


### PR DESCRIPTION
Signed-off-by: Kevin O'Donnell <kevin@blockchaintp.com>
